### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#KinWin
-##A minimalist DOM manipulation library.
+# KinWin
+## A minimalist DOM manipulation library.
 
-###Usage
+### Usage
 
 Just include kinwin.js inside your webpage like this:
 
@@ -11,7 +11,7 @@ All methods can be accessed using the `kw` operator like this:
 
 `kw('.someClass').hide();`
 
-###Available methods:
+### Available methods:
 
 1. get
 2. set
@@ -23,7 +23,7 @@ All methods can be accessed using the `kw` operator like this:
 8. prepend
 9. remove
 
-###Selectors
+### Selectors
 
 id and class syntax same as DOM API:
 + id: `kw.('#id-attribute')` returns node with matching id attribute value
@@ -33,12 +33,12 @@ name attribute and tagName syntax requires special first characters:
 + name: `kw.('@name-attribute')` returns nodes with matching name attribute value
 + tag: `kw.('=tagname')` returns nodes with matching nodeName or tagName
 
-###Test suite
+### Test suite
 "no frills" <a href="https://rawgit.com/aliirz/kinwin.js/master/test/suite.html" 
   target="_blank" title="opens new tab">__html test suite__</a> 
 includes tiny `assert()` method patched on to the `kw` constructor.
 
-####Maybe someday&hellip;
+#### Maybe someday&hellip;
 + attribute selectors? ( i.e., `kw('[attribute...]')')` ~ 7 flavors of attribute selector )
 + contextual selectors? ( i.e., `kw('thing').select('descendant-of-things')` )
 + pseudo-element &amp; pseudo-class


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
